### PR TITLE
use -enable-kvm only if KVM available, use postgres15 for sample vm image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Dockerfile.cross
 
 *.qcow2
 vmlinuz
+neonvm.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:dev
 IMG_RUNNER ?= runner:dev
-VM_EXAMPLE_SOURCE ?= postgres:14-alpine
-VM_EXAMPLE_IMAGE ?= vm-postgres:14-alpine
+VM_EXAMPLE_SOURCE ?= postgres:15-alpine
+VM_EXAMPLE_IMAGE ?= vm-postgres:15-alpine
 
 # kernel for guests
 VM_KERNEL_VERSION ?= "5.15.80"

--- a/controllers/virtualmachine_qmp_queries.go
+++ b/controllers/virtualmachine_qmp_queries.go
@@ -18,7 +18,7 @@ type QmpCpus struct {
 		Props struct {
 			CoreId   int32 `json:"core-id"`
 			ThreadId int32 `json:"thread-id"`
-			SockerId int32 `json:"socket-id"`
+			SocketId int32 `json:"socket-id"`
 		} `json:"props"`
 		VcpusCount int32   `json:"vcpus-count"`
 		QomPath    *string `json:"qom-path"`

--- a/samples/vm-example.yaml
+++ b/samples/vm-example.yaml
@@ -30,7 +30,7 @@ spec:
       max: 4
       use: 4
     rootDisk:
-      image: vm-postgres:14-alpine
+      image: vm-postgres:15-alpine
       #size: 8Gi
     args:
       - -c


### PR DESCRIPTION
- Bare metal hosts not necessary. Now NeonVM able to run on hosts without KVM (TCG accelerator will be used by default)
- `postgres:15-alpine` docker image used as source for vm disk image in local development