### PR TITLE
Add VirtualMachineSpec.{SchedulerName,ServiceAccountName}

### DIFF
--- a/apis/neonvm/v1/virtualmachine_types.go
+++ b/apis/neonvm/v1/virtualmachine_types.go
@@ -44,10 +44,12 @@ type VirtualMachineSpec struct {
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds"`
 
-	NodeSelector map[string]string           `json:"nodeSelector,omitempty"`
-	Affinity     *corev1.Affinity            `json:"affinity,omitempty"`
-	Tolerations  []corev1.Toleration         `json:"tolerations,omitempty"`
-	PodResources corev1.ResourceRequirements `json:"podResources,omitempty"`
+	NodeSelector       map[string]string           `json:"nodeSelector,omitempty"`
+	Affinity           *corev1.Affinity            `json:"affinity,omitempty"`
+	Tolerations        []corev1.Toleration         `json:"tolerations,omitempty"`
+	SchedulerName      string                      `json:"schedulerName,omitempty"`
+	ServiceAccountName string                      `json:"serviceAccountName,omitempty"`
+	PodResources       corev1.ResourceRequirements `json:"podResources,omitempty"`
 
 	// +kubebuilder:default:=Never
 	// +optional

--- a/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -1229,6 +1229,10 @@ spec:
                 - OnFailure
                 - Never
                 type: string
+              schedulerName:
+                type: string
+              serviceAccountName:
+                type: string
               terminationGracePeriodSeconds:
                 default: 5
                 format: int64

--- a/controllers/virtualmachine_controller.go
+++ b/controllers/virtualmachine_controller.go
@@ -487,6 +487,8 @@ func (r *VirtualMachineReconciler) podForVirtualMachine(
 			NodeSelector:                  virtualmachine.Spec.NodeSelector,
 			ImagePullSecrets:              virtualmachine.Spec.ImagePullSecrets,
 			Tolerations:                   virtualmachine.Spec.Tolerations,
+			ServiceAccountName:            virtualmachine.Spec.ServiceAccountName,
+			SchedulerName:                 virtualmachine.Spec.SchedulerName,
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{


### PR DESCRIPTION
Required for autoscaling.

Todo: configs at /etc/kubernetes/... from `ServiceAccountName` should be passed through to the VM. Might be worthwhile splitting out `SchedulerName` and leaving `ServiceAccountName` in `sharnoff/dev` for now.