### PR TITLE
vm-builder: Don't pull image if already present

### DIFF
--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -267,7 +267,7 @@ func main() {
 
 	if !hostContainsSrcImage {
 		// pull source image
-		log.Printf("Pull source docker image: %s\n", *srcImage)
+		log.Printf("Pull source docker image: %s", *srcImage)
 		pull, err := cli.ImagePull(ctx, *srcImage, types.ImagePullOptions{})
 		if err != nil {
 			log.Fatalln(err)
@@ -276,11 +276,6 @@ func main() {
 
 		// do quiet pull - discard output
 		io.Copy(io.Discard, pull)
-		/*
-			if err = printReader(pull); err != nil {
-				log.Fatalln(err)
-			}
-		*/
 	}
 
 	log.Printf("Build docker image for virtual machine (disk size %s): %s\n", *size, dstIm)

--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -182,10 +182,11 @@ done
 )
 
 var (
-	srcImage = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
-	dstImage = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
-	size     = flag.String("size", "1G", `Size for disk image: --size=1G`)
-	outFile  = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
+	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
+	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
+	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	forcePull = flag.Bool("pull", false, `Pull src image even if already present locally`)
 )
 
 func printReader(reader io.ReadCloser) error {
@@ -248,20 +249,22 @@ func main() {
 	defer cli.Close()
 
 	hostContainsSrcImage := false
-	hostImages, err := cli.ImageList(ctx, types.ImageListOptions{})
-	if err != nil {
-		log.Fatalln(err)
-	}
+	if !*forcePull {
+		hostImages, err := cli.ImageList(ctx, types.ImageListOptions{})
+		if err != nil {
+			log.Fatalln(err)
+		}
 
-	for _, img := range hostImages {
-		for _, name := range img.RepoTags {
-			if name == *srcImage {
-				hostContainsSrcImage = true
+		for _, img := range hostImages {
+			for _, name := range img.RepoTags {
+				if name == *srcImage {
+					hostContainsSrcImage = true
+					break
+				}
+			}
+			if hostContainsSrcImage {
 				break
 			}
-		}
-		if hostContainsSrcImage {
-			break
 		}
 	}
 


### PR DESCRIPTION
The current solution has some rough edges, but I'm not familiar enough with the Docker go api to sort them out yet.

For now, this only works if you (at least) specify the image tag explicitly - e.g. "vmdata-temp:latest" instead of "vmdata-temp".