### PR TITLE
make: remove 'buildvcs=false' from manifest gen

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ env:
   KUSTOMIZE_VERSION:        "4.5.7"
   CONTROLLER_TOOLS_VERSION: "0.10.0"
   CODE_GENERATOR_VERSION:   "0.25.4"
-  GOFLAGS:                  "-buildvcs=false"
   IMG:                      "neondatabase/neonvm-controller"
   IMG_RUNNER:               "neondatabase/neonvm-runner"
   VM_KERNEL_IMAGE:          "neondatabase/vm-kernel"

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,9 @@ generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 	rm -rf $$iidfile
 	go fmt ./...
 
-# if buildvcs=false is not given, then we can run into issues with git worktrees.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	GOFLAGS="-buildvcs=false" $(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
This was previously introduced in d3df2278dd03487adba93b31493426fc81459e99, and was required there to handle git worktrees because it was running in a container, which might not have had access to the .git directory outside the worktree.

However, because 9a7a79b93efa34286648c146559e599d7e2ac65e switched back to running it outside the container, it's no longer required.