### PR TITLE
Change vector addresses [::] -> 0.0.0.0

### DIFF
--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -190,7 +190,7 @@ done
 data_dir: /tmp
 api:
   enabled: true
-  address: "[::]:8686"
+  address: "0.0.0.0:8686"
   playground: false
 sources:
   host_metrics:
@@ -214,7 +214,7 @@ sinks:
     inputs:
       - host_metrics
       - internal_metrics
-    address: "[::]:9090"
+    address: "0.0.0.0:9100"
 `
 )
 


### PR DESCRIPTION
Current logs of VMs on staging have repeated vector crashes, for example:

```
2022-12-23T03:55:45.801146Z  INFO vector::internal_events::api: API server running. address=[::]:8686 playground=off
2022-12-23T03:55:45.803415Z ERROR vector::sinks::prometheus::exporter: Server bind error: TCP bind failed: Address family not supported by protocol (os error 97).
thread 'main' panicked at 'error binding to [::]:8686: error creating server listener: Address family not supported by protocol (os error 97)', /cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.3/src/server.rs:283:27
```

Editing the config _seemed_ to fix the main problem, and I was able to get the metrics from inside the VM, **but not outside it** (although, if that's specifically because I changed it to port `9100`, then perhaps we're ok).