### PR TITLE
make vector configuration more plugable

### DIFF
--- a/samples/vm-example.yaml
+++ b/samples/vm-example.yaml
@@ -14,6 +14,16 @@ spec:
     protocol: TCP
     targetPort: postgres
     nodePort: 30632
+  - name: host-metrics
+    port: 9100
+    protocol: TCP
+    targetPort: host-metrics
+    nodePort: 30100
+  - name: metrics
+    port: 9187
+    protocol: TCP
+    targetPort: metrics
+    nodePort: 30187
   type: NodePort
   selector:
     vm.neon.tech/name: example
@@ -49,24 +59,39 @@ spec:
         port: 5432
       - name: pooler
         port: 5432
+      - name: host-metrics
+        port: 9100
+      - name: metrics
+        port: 9187
   disks:
     - name: pgdata
       mountPath: /var/lib/postgresql
       emptyDisk:
         size: 16Gi
-    - name: config
+    - name: postgres-config
       mountPath: /etc/postgresql
       configMap:
-        name: postgresql-config
+        name: example-config
+        items:
+          - key: postgresql.conf
+            path: postgresql.conf
+    - name: vector-config
+      mountPath: /etc/vector
+      configMap:
+        name: example-config
+        items:
+          - key: vector.yaml
+            path: vector.yaml
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: postgresql-config
+  name: example-config
 data:
   postgresql.conf: |
     listen_addresses = '*'
+    shared_preload_libraries = 'pg_stat_statements'
 
     max_connections = 64
     shared_buffers = 2GB
@@ -84,3 +109,18 @@ data:
     max_parallel_workers_per_gather = 4
     max_parallel_workers = 8
     max_parallel_maintenance_workers = 4
+
+  vector.yaml: |
+    sources:
+      postgresql_metrics:
+        type: postgresql_metrics
+        endpoints:
+          - "postgres://postgres@localhost:5432"
+        exclude_databases:
+          - "^template.*"
+    sinks:
+      postgres_exporter:
+        type: prometheus_exporter
+        inputs:
+          - postgresql_metrics
+        address: "0.0.0.0:9187"

--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -75,7 +75,7 @@ RUN set -e \
 RUN set -e \
     && wget https://packages.timber.io/vector/0.26.0/vector-0.26.0-x86_64-unknown-linux-musl.tar.gz -O - \
     | tar xzvf - --strip-components 3 -C /neonvm/bin/ ./vector-x86_64-unknown-linux-musl/bin/vector
-    
+
 # init scripts
 ADD inittab  /neonvm/bin/inittab
 ADD vminit   /neonvm/bin/vminit
@@ -133,7 +133,7 @@ fi
 ::sysinit:/neonvm/bin/vminit
 ::respawn:/neonvm/bin/udevd
 ::respawn:/neonvm/bin/acpid -f -c /neonvm/acpi
-::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml
+::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml --config-dir /etc/vector
 ::respawn:/neonvm/bin/vmstart
 ttyS0::respawn:/neonvm/bin/agetty --8bits --local-line --noissue --noclear --noreset --host console --login-program /neonvm/bin/login --login-pause --autologin root 115200 ttyS0 linux
 `
@@ -202,18 +202,11 @@ sources:
       mountPoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
-  postgresql_metrics:
-    endpoints:
-      - "postgres://postgres@localhost:5432"
-    type: postgresql_metrics
-  internal_metrics:
-    type: internal_metrics
 sinks:
   prom_exporter:
     type: prometheus_exporter
     inputs:
       - host_metrics
-      - internal_metrics
     address: "0.0.0.0:9100"
 `
 )


### PR DESCRIPTION
- removed vector internal metrics at all
- removed `postgresql_source` from default vector config
- added `--config-dir /etc/vector` for vector, it allows mount additional configs

Why ? 

`postgres_source` could (and would) have different configurations. For vanilla postgres endpoint will be `postgres://postgres@localhost:5432` but for compute-node we have other user (`cloud_admin`). So, by default vector has only host metrics collector and one sink in prometheus format.

`samples/vm-example.yaml` modified to demonstrate plugable vector configs (added `postgresql_source` and one more sink in prom format as well but on other port)
