### PR TITLE
Vector setup fixes

### DIFF
--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -203,18 +203,11 @@ sources:
       mountPoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
-  postgresql_metrics:
-    type: postgresql_metrics
-    endpoints:
-      - "postgres://cloud_admin@localhost:5432/postgres"
-    exclude_databases:
-      - "^template.*"
 sinks:
   prom_exporter:
     type: prometheus_exporter
     inputs:
       - host_metrics
-      - postgresql_metrics
     address: "0.0.0.0:9100"
 `
 )

--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -82,7 +82,6 @@ ADD vminit   /neonvm/bin/vminit
 ADD vmstart  /neonvm/bin/vmstart
 ADD vmacpi   /neonvm/acpi/vmacpi
 ADD vector.yaml /neonvm/config/vector.yaml
-RUN mkdir /etc/vector
 RUN chmod +x /neonvm/bin/vminit /neonvm/bin/vmstart
 
 FROM vm-runtime AS builder
@@ -91,6 +90,7 @@ COPY --from=rootdisk / /rootdisk
 COPY --from=vm-runtime /neonvm /rootdisk/neonvm
 RUN set -e \
     && mkdir -p /rootdisk/etc \
+    && mkdir /rootdisk/etc/vector \
     && cp -f /rootdisk/neonvm/bin/inittab /rootdisk/etc/inittab \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2


### PR DESCRIPTION
First commit  reverts 3552066 -- I'll move that config to the control plane.

Second commit creates an empty directory for vector when no vector config is present in the VM spec. Now vector whines if there is no config in spec:
```
2023-01-06T11:28:22.712295Z ERROR vector::config::loading: Config file not found in path. path="/etc/vector"
2023-01-06T11:28:22.710651Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,lapin=info,kube=info"
2023-01-06T11:28:22.709390Z  INFO vector::app: Internal log rate limit configured. internal_log_rate_secs=10
```
