### PR TITLE
Switch version tags from X.Y.Z -> vX.Y.Z

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "*.*.*"
+      - "v*.*.*"
 
 env:
   KUSTOMIZE_VERSION:        "4.5.7"


### PR DESCRIPTION
I _think_ version tags as we have them right now don't work with go modules; they have to be prefixed with "v", e.g. `v1.2.3` instead of `1.2.3`. It's (somewhat) described here: <https://go.dev/blog/publishing-go-modules#semantic-versions-and-modules>.