### PR TITLE
tmpfs: add tmpfs mount to disk

### DIFF
--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -169,6 +169,10 @@ mount -t cgroup cgroup /sys/fs/cgroup
 mount -t devpts -o noexec,nosuid       devpts    /dev/pts
 mount -t tmpfs  -o noexec,nosuid,nodev shm-tmpfs /dev/shm
 
+# mount a big diskcache
+mkdir -p /neonvm/cache
+mount -t tmpfs -o size=100G tmpfs /neonvm/cache
+
 # neonvm runtime params mounted as iso9660 disk
 mount -o ro,mode=0644 /dev/vdb /neonvm/runtime
 
@@ -197,11 +201,11 @@ sources:
   host_metrics:
     filesystem:
       devices:
-        excludes: [binfmt_misc]
+	excludes: [binfmt_misc]
       filesystems:
-        excludes: [binfmt_misc]
+	excludes: [binfmt_misc]
       mountPoints:
-        excludes: ["*/proc/sys/fs/binfmt_misc"]
+	excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
 sinks:
   prom_exporter:


### PR DESCRIPTION
You can make tmpfses larger than the avalible ram (just so long as we
don't ever use it). 100 seems big, but we could make it smaller once
we find a reasonable cap.

The decision to use `/neonvm/cache` is totally arbitrary.