### PR TITLE
virtualmachine_controller: fix assignment to entry in nil map

### DIFF
--- a/controllers/virtualmachine_controller.go
+++ b/controllers/virtualmachine_controller.go
@@ -195,7 +195,7 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	statusBefore := virtualmachine.Status.DeepCopy()
 	if err := r.doReconcile(ctx, &virtualmachine); err != nil {
 		r.Recorder.Eventf(&virtualmachine, corev1.EventTypeWarning, "Failed",
-			"Failed to reconcile (%s): %s", &virtualmachine.Name, err)
+			"Failed to reconcile (%s): %s", virtualmachine.Name, err)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/virtualmachine_controller.go
+++ b/controllers/virtualmachine_controller.go
@@ -750,7 +750,10 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 
 	// use multus network tp add extra network interface
 	if virtualmachine.Spec.ExtraNetwork != nil {
-		pod.Annotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf("%s@%s", virtualmachine.Spec.ExtraNetwork.MultusNetwork, virtualmachine.Spec.ExtraNetwork.Interface)
+		if pod.ObjectMeta.Annotations == nil {
+			pod.ObjectMeta.Annotations = map[string]string{}
+		}
+		pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf("%s@%s", virtualmachine.Spec.ExtraNetwork.MultusNetwork, virtualmachine.Spec.ExtraNetwork.Interface)
 	}
 
 	return pod, nil


### PR DESCRIPTION
This PR fixes the following error:

```
panic: assignment to entry in nil map

goroutine 247 [running]:
github.com/neondatabase/neonvm/controllers.podSpec(0xc0006aa400)
	/workspace/controllers/virtualmachine_controller.go:753 +0xee7
github.com/neondatabase/neonvm/controllers.(*VirtualMachineReconciler).podForVirtualMachine(0xc0007e11a0, 0xc000710500?)
	/workspace/controllers/virtualmachine_controller.go:539 +0x2a
github.com/neondatabase/neonvm/controllers.(*VirtualMachineReconciler).doReconcile(0xc0007e11a0, {0x1a102f8, 0xc00048a480}, 0xc0006aa400)
	/workspace/controllers/virtualmachine_controller.go:322 +0x1d5c
github.com/neondatabase/neonvm/controllers.(*VirtualMachineReconciler).Reconcile(0xc0007e11a0, {0x1a102f8, 0xc00048a480}, {{{0xc00013e460?, 0x16dc100?}, {0xc00062cb70?, 0x30?}}})
	/workspace/controllers/virtualmachine_controller.go:196 +0x3bf
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc00070c370, {0x1a102f8, 0xc00048a3f0}, {{{0xc00013e460?, 0x16dc100?}, {0xc00062cb70?, 0x4045d4?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114 +0x28b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00070c370, {0x1a10250, 0xc0007e8180}, {0x1609860?, 0xc0004400a0?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311 +0x352
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00070c370, {0x1a10250, 0xc0007e8180})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:223 +0x31c
```

Also, use `pod.ObjectMeta.Annotations` instead of `pod.Annotations`
And fix VM name in `Failed to reconcile (%!s(*string=0xc000a88020))` error message