### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NeonVM: QEMU-based virtualization API and controlller for Kubernetes
+# NeonVM: QEMU-based virtualization API and controller for Kubernetes
 
 ## Description
 
@@ -129,7 +129,7 @@ kubectl exec -it $VM_POD -- screen /dev/pts/0
 
 <press Enter to see output>
 ```
-to exit from console presss `CTRL-a k` (see manual for `screen` tool)
+to exit from console press `CTRL-a k` (see manual for `screen` tool)
 
 #### 5. Plug/Unplug CPUs in VM
 

--- a/apis/neonvm/v1/virtualmachine_types.go
+++ b/apis/neonvm/v1/virtualmachine_types.go
@@ -87,7 +87,7 @@ type Guest struct {
 	MemorySlots MemorySlots `json:"memorySlots"`
 	// +optional
 	RootDisk RootDisk `json:"rootDisk"`
-	// Docker image Entrypoint array replcacement.
+	// Docker image Entrypoint array replacement.
 	// +optional
 	Command []string `json:"command,omitempty"`
 	// Arguments to the entrypoint.
@@ -224,7 +224,7 @@ type TmpfsDiskSource struct {
 }
 
 type ExtraNetwork struct {
-	// Enable extra netowrk interface
+	// Enable extra network interface
 	// +kubebuilder:default:=false
 	// +optional
 	Enable bool `json:"enable"`

--- a/config/common/certmanager/certificate.yaml
+++ b/config/common/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: neonvm

--- a/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -1080,7 +1080,7 @@ spec:
                 properties:
                   enable:
                     default: false
-                    description: Enable extra netowrk interface
+                    description: Enable extra network interface
                     type: boolean
                   interface:
                     default: net1
@@ -1100,7 +1100,7 @@ spec:
                       type: string
                     type: array
                   command:
-                    description: Docker image Entrypoint array replcacement.
+                    description: Docker image Entrypoint array replacement.
                     items:
                       type: string
                     type: array

--- a/config/common/rbac/service_account.yaml
+++ b/config/common/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller
+    app.kubernetes.io/instance: controller
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: neonvm
     app.kubernetes.io/part-of: neonvm

--- a/controllers/virtualmachine_controller.go
+++ b/controllers/virtualmachine_controller.go
@@ -224,7 +224,7 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		break
 	}
 	if try >= 10 {
-		return ctrl.Result{}, fmt.Errorf("unable update .specextraNetwork for virtualmachine %s in %d attemps", virtualmachine.Name, try)
+		return ctrl.Result{}, fmt.Errorf("unable update .specextraNetwork for virtualmachine %s in %d attempts", virtualmachine.Name, try)
 	}
 
 	return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -307,7 +307,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 				virtualmachine.Status.ExtraNetIP = ip.String()
 				virtualmachine.Status.ExtraNetMask = fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
 
-				r.Recorder.Event(virtualmachine, "Normal", "Aqcuired",
+				r.Recorder.Event(virtualmachine, "Normal", "Acquired",
 					fmt.Sprintf("Acquired IP %s for VirtualMachine %s",
 						virtualmachine.Status.ExtraNetIP,
 						virtualmachine.Name))
@@ -423,7 +423,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 				}
 			}
 
-			// get CPU details from QEMU and upate status
+			// get CPU details from QEMU and update status
 			cpusPlugged, _, err := QmpGetCpus(virtualmachine)
 			if err != nil {
 				log.Error(err, "Failed to get CPU details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
@@ -461,7 +461,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 				}
 			}
 
-			// get Memory details from hypervisor and upate VM status
+			// get Memory details from hypervisor and update VM status
 			memorySize, err := QmpGetMemorySize(virtualmachine)
 			if err != nil {
 				log.Error(err, "Failed to get Memory details from VirtualMachine", "VirtualMachine", virtualmachine.Name)

--- a/controllers/virtualmachine_qmp_queries.go
+++ b/controllers/virtualmachine_qmp_queries.go
@@ -172,7 +172,7 @@ func QmpPlugCpu(virtualmachine *vmv1.VirtualMachine) error {
 		return err
 	}
 	if len(empty) == 0 {
-		return errors.New("No empy slots for CPU hotplug")
+		return errors.New("No empty slots for CPU hotplug")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -181,7 +181,7 @@ func QmpPlugCpu(virtualmachine *vmv1.VirtualMachine) error {
 	}
 	defer mon.Disconnect()
 
-	// empty list reversed, first cpu slot in the end of list and last cpu slot in the begining
+	// empty list reversed, first cpu slot in the end of list and last cpu slot in the beginning
 	slot := empty[len(empty)-1]
 	qmpcmd := []byte(fmt.Sprintf(`{"execute": "device_add", "arguments": {"id": "cpu%d", "driver": "%s", "core-id": %d, "socket-id": 0,  "thread-id": 0}}`, slot.Core, slot.Type, slot.Core))
 
@@ -199,7 +199,7 @@ func QmpPlugCpuToRunner(ip string, port int32) error {
 		return err
 	}
 	if len(empty) == 0 {
-		return errors.New("No empy slots for CPU hotplug")
+		return errors.New("No empty slots for CPU hotplug")
 	}
 
 	mon, err := QmpConnectByIP(ip, port)
@@ -208,7 +208,7 @@ func QmpPlugCpuToRunner(ip string, port int32) error {
 	}
 	defer mon.Disconnect()
 
-	// empty list reversed, first cpu slot in the end of list and last cpu slot in the begining
+	// empty list reversed, first cpu slot in the end of list and last cpu slot in the beginning
 	slot := empty[len(empty)-1]
 	qmpcmd := []byte(fmt.Sprintf(`{"execute": "device_add", "arguments": {"id": "cpu%d", "driver": "%s", "core-id": %d, "socket-id": 0,  "thread-id": 0}}`, slot.Core, slot.Type, slot.Core))
 
@@ -302,7 +302,7 @@ func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	// check if available mmory slots present
 	plugged := int32(len(memoryDevices))
 	if plugged >= slots {
-		return errors.New("No empy slots for Memory hotplug")
+		return errors.New("No empty slots for Memory hotplug")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -312,7 +312,7 @@ func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	defer mon.Disconnect()
 
 	// add memdev object for next slot
-	// firstly check if such obect already present to avoid repeats
+	// firstly check if such object already present to avoid repeats
 	cmd := []byte(fmt.Sprintf(`{"execute": "qom-list", "arguments": {"path": "/objects/memslot%d"}}`, plugged+1))
 	_, err = mon.Run(cmd)
 	if err != nil {
@@ -327,7 +327,7 @@ func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	cmd = []byte(fmt.Sprintf(`{"execute": "device_add", "arguments": {"id": "dimm%d", "driver": "pc-dimm", "memdev": "memslot%d"}}`, plugged+1, plugged+1))
 	_, err = mon.Run(cmd)
 	if err != nil {
-		// device_add comand failed... so try remove object that we just created
+		// device_add command failed... so try remove object that we just created
 		cmd = []byte(fmt.Sprintf(`{"execute": "object-del", "arguments": {"id": "memslot%d"}}`, plugged+1))
 		mon.Run(cmd)
 		return err
@@ -350,7 +350,7 @@ func QmpPlugMemoryToRunner(ip string, port int32, size int64) error {
 	defer mon.Disconnect()
 
 	// add memdev object for next slot
-	// firstly check if such obect already present to avoid repeats
+	// firstly check if such object already present to avoid repeats
 	cmd := []byte(fmt.Sprintf(`{"execute": "qom-list", "arguments": {"path": "/objects/memslot%d"}}`, plugged+1))
 	_, err = mon.Run(cmd)
 	if err != nil {
@@ -365,7 +365,7 @@ func QmpPlugMemoryToRunner(ip string, port int32, size int64) error {
 	cmd = []byte(fmt.Sprintf(`{"execute": "device_add", "arguments": {"id": "dimm%d", "driver": "pc-dimm", "memdev": "memslot%d"}}`, plugged+1, plugged+1))
 	_, err = mon.Run(cmd)
 	if err != nil {
-		// device_add comand failed... so try remove object that we just created
+		// device_add command failed... so try remove object that we just created
 		cmd = []byte(fmt.Sprintf(`{"execute": "object-del", "arguments": {"id": "memslot%d"}}`, plugged+1))
 		mon.Run(cmd)
 		return err

--- a/controllers/virtualmachinemigration_controller.go
+++ b/controllers/virtualmachinemigration_controller.go
@@ -307,7 +307,7 @@ func (r *VirtualMachineMigrationReconciler) doReconcile(ctx context.Context, vir
 			r.Recorder.Event(virtualmachinemigration, "Normal", "Created",
 				fmt.Sprintf("Created Target Pod for VirtualMachine %s",
 					vm.Name))
-			// once more retrive just created target pod details
+			// once more retrieve just created target pod details
 			r.Get(ctx, types.NamespacedName{Name: virtualmachinemigration.Status.TargetPodName, Namespace: virtualmachinemigration.Namespace}, targetRunner)
 		} else if err != nil {
 			log.Error(err, "Failed to get Target Pod")
@@ -391,17 +391,17 @@ func (r *VirtualMachineMigrationReconciler) doReconcile(ctx context.Context, vir
 				r.Recorder.Event(virtualmachinemigration, "Normal", "Started",
 					fmt.Sprintf("VirtualMachine (%s) live migration started to target pod (%s)",
 						vm.Name, targetRunner.Name))
-				// finnaly update migration phase to Running
+				// finally update migration phase to Running
 				virtualmachinemigration.Status.Phase = vmv1.VmmRunning
 			}
 		case corev1.PodSucceeded:
-			// target runner pod finsihed without error? but it shouldn't finish
+			// target runner pod finished without error? but it shouldn't finish
 			virtualmachinemigration.Status.Phase = vmv1.VmmFailed
 			meta.SetStatusCondition(&virtualmachinemigration.Status.Conditions,
 				metav1.Condition{Type: typeDegradedVirtualMachineMigration,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Reconciling",
-					Message: fmt.Sprintf("Target Pod (%s) for VirtualMachine (%s) copmpleted", targetRunner.Name, vm.Name)})
+					Message: fmt.Sprintf("Target Pod (%s) for VirtualMachine (%s) completed", targetRunner.Name, vm.Name)})
 		case corev1.PodFailed:
 			virtualmachinemigration.Status.Phase = vmv1.VmmFailed
 			meta.SetStatusCondition(&virtualmachinemigration.Status.Conditions,
@@ -421,7 +421,7 @@ func (r *VirtualMachineMigrationReconciler) doReconcile(ctx context.Context, vir
 		}
 
 	case vmv1.VmmRunning:
-		// retrive target pod details
+		// retrieve target pod details
 		targetRunner := &corev1.Pod{}
 		err := r.Get(ctx, types.NamespacedName{Name: virtualmachinemigration.Status.TargetPodName, Namespace: virtualmachinemigration.Namespace}, targetRunner)
 		if err != nil && apierrors.IsNotFound(err) {
@@ -442,7 +442,7 @@ func (r *VirtualMachineMigrationReconciler) doReconcile(ctx context.Context, vir
 			log.Error(err, "Failed to get target runner Pod")
 			return err
 		}
-		// retrive migration statistics and put it in Status
+		// retrieve migration statistics and put it in Status
 		migrationInfo, err := QmpGetMigrationInfo(vm)
 		if err != nil {
 			log.Error(err, "Failed to get migration info")

--- a/samples/vm-example/init
+++ b/samples/vm-example/init
@@ -11,7 +11,7 @@ mkdir -p /dev/shm
 chmod 1777 /dev/shm
 mount -t tmpfs tmp /dev/shm
 
-# start udev (mostlry used for auto-online hotplugged CPUs)
+# start udev (mostly used for auto-online hotplugged CPUs)
 udevd --daemon
 
 # networking
@@ -35,6 +35,6 @@ while true; do
   sleep 1
 done
 
-echo "Exiting and shuting down vm"
+echo "Exiting and shutting down vm"
 su-exec postgres pg_ctl stop
 poweroff -f

--- a/tools/vxlan/controller/main.go
+++ b/tools/vxlan/controller/main.go
@@ -101,7 +101,7 @@ func main() {
 		log.Printf("found %d ip addresses", len(nodeIPs))
 
 		// update FDB
-		log.Print("udpate FDB table")
+		log.Print("update FDB table")
 		if err := updateFDB(VXLAN_IF_NAME, nodeIPs, ownNodeIP); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
These are just the ones noticed by codespell, plus whatever else I saw while getting there. There's definitely others I haven't caught, but this should be a good enough start :)

I wasn't sure what some of the typos are intended to be - see below:

https://github.com/neondatabase/neonvm/blob/3efd95a9b9f0379735d22bad0729965f4fcd4cdf/controllers/virtualmachine_controller.go#L523

(not sure whether it's "or" or "not")

https://github.com/neondatabase/neonvm/blob/3efd95a9b9f0379735d22bad0729965f4fcd4cdf/controllers/virtualmachinemigration_controller.go#L221

(not sure whether it's "what" or "want")

@cicdteam any ideas?