### PR TITLE
Fix staticcheck linter warnings

### DIFF
--- a/controllers/virtualmachine_controller.go
+++ b/controllers/virtualmachine_controller.go
@@ -32,6 +32,7 @@ import (
 	goipamapiv1 "github.com/cicdteam/go-ipam/api/v1"
 	"github.com/cicdteam/go-ipam/api/v1/apiv1connect"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -602,7 +603,7 @@ func imageForVmRunner() (string, error) {
 	var imageEnvVar = "VM_RUNNER_IMAGE"
 	image, found := os.LookupEnv(imageEnvVar)
 	if !found {
-		return "", fmt.Errorf("Unable to find %s environment variable with the image", imageEnvVar)
+		return "", fmt.Errorf("unable to find %s environment variable with the image", imageEnvVar)
 	}
 	return image, nil
 }
@@ -772,10 +773,10 @@ func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func waitForGrpc(ctx context.Context, addr string) {
 	log := log.FromContext(ctx)
 
-	dialAddr := strings.TrimLeft(addr, "http://")
+	dialAddr := strings.TrimPrefix(addr, "http://")
 	dialTimeout := 5 * time.Second
 	dialOpts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 	}
 	log.Info("check grpc connection", "address", dialAddr)
@@ -880,8 +881,6 @@ func DeepEqual(v1, v2 interface{}) bool {
 	var x2 interface{}
 	bytesB, _ := json.Marshal(v2)
 	_ = json.Unmarshal(bytesB, &x2)
-	if reflect.DeepEqual(x1, x2) {
-		return true
-	}
-	return false
+
+	return reflect.DeepEqual(x1, x2)
 }

--- a/controllers/virtualmachine_qmp_queries.go
+++ b/controllers/virtualmachine_qmp_queries.go
@@ -115,7 +115,7 @@ func QmpGetCpus(virtualmachine *vmv1.VirtualMachine) ([]QmpCpuSlot, []QmpCpuSlot
 	}
 	defer mon.Disconnect()
 
-	qmpcmd := []byte(`{ "execute": "query-hotpluggable-cpus"}`)
+	qmpcmd := []byte(`{"execute": "query-hotpluggable-cpus"}`)
 	raw, err := mon.Run(qmpcmd)
 	if err != nil {
 		return nil, nil, err
@@ -144,7 +144,7 @@ func QmpGetCpusFromRunner(ip string, port int32) ([]QmpCpuSlot, []QmpCpuSlot, er
 	}
 	defer mon.Disconnect()
 
-	qmpcmd := []byte(`{ "execute": "query-hotpluggable-cpus"}`)
+	qmpcmd := []byte(`{"execute": "query-hotpluggable-cpus"}`)
 	raw, err := mon.Run(qmpcmd)
 	if err != nil {
 		return nil, nil, err
@@ -172,7 +172,7 @@ func QmpPlugCpu(virtualmachine *vmv1.VirtualMachine) error {
 		return err
 	}
 	if len(empty) == 0 {
-		return errors.New("No empy slots for CPU hotplug")
+		return errors.New("no empty slots for CPU hotplug")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -199,7 +199,7 @@ func QmpPlugCpuToRunner(ip string, port int32) error {
 		return err
 	}
 	if len(empty) == 0 {
-		return errors.New("No empy slots for CPU hotplug")
+		return errors.New("no empty slots for CPU hotplug")
 	}
 
 	mon, err := QmpConnectByIP(ip, port)
@@ -236,7 +236,7 @@ func QmpUnplugCpu(virtualmachine *vmv1.VirtualMachine) error {
 		}
 	}
 	if !found {
-		return errors.New("There are no unpluggable CPUs")
+		return errors.New("there are no unpluggable CPUs")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -264,7 +264,7 @@ func QmpQueryMemoryDevices(virtualmachine *vmv1.VirtualMachine) ([]QmpMemoryDevi
 	defer mon.Disconnect()
 
 	var result QmpMemoryDevices
-	cmd := []byte(`{ "execute": "query-memory-devices"}`)
+	cmd := []byte(`{"execute": "query-memory-devices"}`)
 	raw, err := mon.Run(cmd)
 	if err != nil {
 		return nil, err
@@ -281,7 +281,7 @@ func QmpQueryMemoryDevicesFromRunner(ip string, port int32) ([]QmpMemoryDevice, 
 	defer mon.Disconnect()
 
 	var result QmpMemoryDevices
-	cmd := []byte(`{ "execute": "query-memory-devices"}`)
+	cmd := []byte(`{"execute": "query-memory-devices"}`)
 	raw, err := mon.Run(cmd)
 	if err != nil {
 		return nil, err
@@ -302,7 +302,7 @@ func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	// check if available mmory slots present
 	plugged := int32(len(memoryDevices))
 	if plugged >= slots {
-		return errors.New("No empy slots for Memory hotplug")
+		return errors.New("no empy slots for Memory hotplug")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -381,7 +381,7 @@ func QmpUnplugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	}
 	plugged := len(memoryDevices)
 	if plugged == 0 {
-		return errors.New("There are no unpluggable Memory slots")
+		return errors.New("there are no unpluggable Memory slots")
 	}
 
 	mon, err := QmpConnect(virtualmachine)
@@ -416,7 +416,7 @@ func QmpGetMemorySize(virtualmachine *vmv1.VirtualMachine) (*resource.Quantity, 
 	}
 	defer mon.Disconnect()
 
-	qmpcmd := []byte(`{ "execute": "query-memory-size-summary"}`)
+	qmpcmd := []byte(`{"execute": "query-memory-size-summary"}`)
 	raw, err := mon.Run(qmpcmd)
 	if err != nil {
 		return nil, err
@@ -455,8 +455,8 @@ func QmpStartMigration(virtualmachine *vmv1.VirtualMachine, virtualmachinemigrat
 	}
 	defer tmon.Disconnect()
 
-	qmpcmd := []byte{}
 	cache := resource.MustParse("256Mi")
+	var qmpcmd []byte
 	// setup migration on source runner
 	qmpcmd = []byte(fmt.Sprintf(`{
 		"execute": "migrate-set-capabilities",
@@ -535,7 +535,7 @@ func QmpStartMigration(virtualmachine *vmv1.VirtualMachine, virtualmachinemigrat
 	if err != nil {
 		return err
 	}
-	qmpcmd = []byte(fmt.Sprintf(`{"execute": "migrate-start-postcopy"}`))
+	qmpcmd = []byte(`{"execute": "migrate-start-postcopy"}`)
 	_, err = smon.Run(qmpcmd)
 	if err != nil {
 		return err
@@ -552,7 +552,7 @@ func QmpGetMigrationInfo(virtualmachine *vmv1.VirtualMachine) (MigrationInfo, er
 	}
 	defer mon.Disconnect()
 
-	qmpcmd := []byte(`{ "execute": "query-migrate"}`)
+	qmpcmd := []byte(`{"execute": "query-migrate"}`)
 	raw, err := mon.Run(qmpcmd)
 	if err != nil {
 		return empty, err
@@ -571,7 +571,7 @@ func QmpQuit(ip string, port int32) error {
 	}
 	defer mon.Disconnect()
 
-	qmpcmd := []byte(fmt.Sprintf(`{"execute": "quit"}`))
+	qmpcmd := []byte(`{"execute": "quit"}`)
 	_, err = mon.Run(qmpcmd)
 	if err != nil {
 		return err

--- a/runner/main.go
+++ b/runner/main.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -79,7 +78,7 @@ func getResolvConf() (*resolveFile, error) {
 
 // GetSpecific returns the contents of the user specified resolv.conf file and its hash
 func getSpecific(path string) (*resolveFile, error) {
-	resolv, err := ioutil.ReadFile(path)
+	resolv, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +140,7 @@ func getLines(input []byte, commentMarker []byte) [][]byte {
 
 func resolvePath() string {
 	detectSystemdResolvConfOnce.Do(func() {
-		candidateResolvConf, err := ioutil.ReadFile(resolveDefaultPath)
+		candidateResolvConf, err := os.ReadFile(resolveDefaultPath)
 		if err != nil {
 			// silencing error as it will resurface at next calls trying to read defaultPath
 			return
@@ -379,10 +378,8 @@ func checkKVM() bool {
 		return false
 	}
 	mode := info.Mode()
-	if mode&os.ModeCharDevice == os.ModeCharDevice {
-		return true
-	}
-	return false
+
+	return mode&os.ModeCharDevice == os.ModeCharDevice
 }
 
 func main() {
@@ -552,6 +549,7 @@ func calcIPs(cidr string) (net.IP, net.IP, net.IPMask, error) {
 	return ip1, ip2, mask, nil
 }
 
+//lint:ignore U1000 the function is not in use right now, but it's good to have for the future
 func execBg(name string, arg ...string) error {
 	cmd := exec.Command(name, arg...)
 	cmd.Stdout = os.Stdout

--- a/tools/vxlan/controller/main.go
+++ b/tools/vxlan/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -314,10 +315,10 @@ func deleteLinkAndAddr(name, ipam string) error {
 }
 
 func waitForGrpc(ctx context.Context, addr string) {
-	dialAddr := strings.TrimLeft(addr, "http://")
+	dialAddr := strings.TrimPrefix(addr, "http://")
 	dialTimeout := 5 * time.Second
 	dialOpts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 	}
 	log.Printf("check grpc connection to service %s", dialAddr)


### PR DESCRIPTION
Accidentally found out that my vscode uses [`staticcheck`](https://staticcheck.io/) and highlights its warnings in the code, so I've decided to fix them. Let me know what do you think and if we should add this to CI / make file to use along with `go vet`

```
# Before:
$ staticcheck  ./...
controllers/virtualmachine_controller.go:605:14: error strings should not be capitalized (ST1005)
controllers/virtualmachine_controller.go:772:37: cutset contains duplicate characters (SA1024)
controllers/virtualmachine_controller.go:775:3: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x.  (SA1019)
controllers/virtualmachine_controller.go:880:2: should use 'return reflect.DeepEqual(x1, x2)' instead of 'if reflect.DeepEqual(x1, x2) { return true }; return false' (S1008)
controllers/virtualmachine_qmp_queries.go:175:10: error strings should not be capitalized (ST1005)
controllers/virtualmachine_qmp_queries.go:202:10: error strings should not be capitalized (ST1005)
controllers/virtualmachine_qmp_queries.go:239:10: error strings should not be capitalized (ST1005)
controllers/virtualmachine_qmp_queries.go:305:10: error strings should not be capitalized (ST1005)
controllers/virtualmachine_qmp_queries.go:384:10: error strings should not be capitalized (ST1005)
controllers/virtualmachine_qmp_queries.go:458:2: this value of qmpcmd is never used (SA4006)
controllers/virtualmachine_qmp_queries.go:538:18: unnecessary use of fmt.Sprintf (S1039)
controllers/virtualmachine_qmp_queries.go:574:19: unnecessary use of fmt.Sprintf (S1039)
runner/main.go:10:2: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
runner/main.go:382:2: should use 'return mode&os.ModeCharDevice == os.ModeCharDevice' instead of 'if mode&os.ModeCharDevice == os.ModeCharDevice { return true }; return false' (S1008)
runner/main.go:555:6: func execBg is unused (U1000)
tools/vxlan/controller/main.go:317:37: cutset contains duplicate characters (SA1024)
tools/vxlan/controller/main.go:320:3: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x.  (SA1019)
$

# After:
$ staticcheck  ./...
$
```