### PR TITLE
Add e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,97 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+      - release
+  pull_request:
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+concurrency:
+  # Allow only one workflow per any non-`main` branch.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'anysha' }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: [ self-hosted, gen3, small ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install dependencies
+        run: |
+          LOCALBIN=$(pwd)/bin
+          mkdir -p ${LOCALBIN}
+
+          # Install kubectl
+          curl -Lo ${LOCALBIN}/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          chmod +x ${LOCALBIN}/kubectl
+
+          # Install kind
+          curl -Lo ${LOCALBIN}/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+          chmod +x ${LOCALBIN}/kind
+
+          # Install kuttl
+          curl -Lo ${LOCALBIN}/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION#v}_linux_x86_64
+          chmod +x ${LOCALBIN}/kubectl-kuttl
+
+          echo ${LOCALBIN} >> $GITHUB_PATH
+        env:
+          KUBECTL_VERSION: v1.26.1
+          KIND_VERSION: v0.17.0
+          KUTTL_VERSION: v0.15.0
+
+      - name: Check dependencies
+        run: |
+          kubectl version --client --output=yaml
+          kind version
+          kubectl kuttl version
+
+      # To save some time use prebuilt vm kernel instead of running `make kernel` (see .github/workflows/release.yaml)
+      - name: Load VM kernel
+        run: |
+          docker pull --quiet ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}
+          ID=$(docker create ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION} true)
+          docker cp ${ID}:/vmlinuz hack/vmlinuz
+          docker rm -f ${ID}
+        env:
+          VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
+          VM_KERNEL_VERSION: "5.15.80"
+
+      - run: make local-cluster
+
+      - run: make deploy
+
+      - name: Run make e2e
+        run: |
+          kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
+
+      - name: Get k8s logs and events
+        if: failure()
+        run: |
+          namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
+          for namespace in $namespaces; do
+            pods=$(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}')
+            for pod in $pods; do
+              echo "*** Namespace=$namespace Pod=$pod ***"
+              echo "Logs:"
+              kubectl logs -n $namespace $pod
+              echo "Events:"
+              kubectl get events --namespace $namespace --field-selector involvedObject.name=$pod
+              echo ""
+            done
+          done
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kind delete cluster

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ fmt: ## Run go fmt against code.
 
 .PHONY: vet
 vet: ## Run go vet against code.
-	go vet ./...
+	# `go vet` requires gcc
+	# ref https://github.com/golang/go/issues/56755
+	CGO_ENABLED=0 go vet ./...
 
 .PHONE: e2e
 e2e: ## Run e2e kuttl tests

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONE: e2e
+e2e: ## Run e2e kuttl tests
+	kubectl kuttl test --config tests/e2e/kuttl-test.yaml
+
 # TODO: fix/write tests
 .PHONY: test
 test: fmt vet envtest ## Run tests.
@@ -151,7 +155,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 DEPLOYTS := $(shell date +%s)
 .PHONY: deploy
 deploy: kind-load manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/common/controller              && $(KUSTOMIZE) edit set image controller=$(IMG)               && $(KUSTOMIZE) edit add annotation deploytime:$(DEPLOYTS) --force
+	cd config/common/controller              && $(KUSTOMIZE) edit set image controller=$(IMG)             && $(KUSTOMIZE) edit add annotation deploytime:$(DEPLOYTS) --force
 	cd config/default-vxlan/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN) && $(KUSTOMIZE) edit add annotation deploytime:$(DEPLOYTS) --force
 	cd config/default-vxlan/vxlan-ipam       && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN) && $(KUSTOMIZE) edit add annotation deploytime:$(DEPLOYTS) --force
 	$(KUSTOMIZE) build config/default-vxlan/multus > neonvm-multus.yaml

--- a/tests/e2e/kuttl-test.yaml
+++ b/tests/e2e/kuttl-test.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+  - tests/e2e
+timeout: 300
+parallel: 1

--- a/tests/e2e/vm-migration/00-assert.yaml
+++ b/tests/e2e/vm-migration/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+---
+apiVersion: vm.neon.tech/v1
+kind: VirtualMachine
+metadata:
+  name: example
+status:
+  phase: Running
+  conditions:
+    - type: Available
+      status: "True"
+---
+apiVersion: v1
+kind: pod
+metadata:
+  name: workload
+status:
+  phase: Running

--- a/tests/e2e/vm-migration/00-prepare.yaml
+++ b/tests/e2e/vm-migration/00-prepare.yaml
@@ -1,0 +1,42 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- ../../../samples/vm-example.yaml
+unitTest: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: workload
+spec:
+  initContainers:
+  - name: wait-for-pg
+    image: postgres:15-alpine
+    command:
+    - sh
+    - "-c"
+    - |
+      set -e
+      until pg_isready --dbname=postgres --host=example --port=5432; do
+        sleep 1
+      done
+  - name: pgbench-initialize
+    image: postgres:15-alpine
+    command:
+    - pgbench
+    args:
+    - postgres://postgres@example:5432/postgres
+    - --initialize
+    - --scale=10
+  containers:
+  - name: pgbench
+    image: postgres:15-alpine
+    command:
+    - pgbench
+    args:
+    - postgres://postgres@example:5432/postgres
+    - --client=2
+    - --progress=1
+    - --progress-timestamp
+    - --time=600
+  restartPolicy: Never

--- a/tests/e2e/vm-migration/01-assert.yaml
+++ b/tests/e2e/vm-migration/01-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+---
+apiVersion: vm.neon.tech/v1
+kind: VirtualMachineMigration
+metadata:
+  name: example
+status:
+  phase: Succeeded
+---
+apiVersion: vm.neon.tech/v1
+kind: VirtualMachine
+metadata:
+  name: example
+status:
+  phase: Running
+  conditions:
+    - type: Available
+      status: "True"
+---
+apiVersion: v1
+kind: pod
+metadata:
+  name: workload
+status:
+  phase: Running

--- a/tests/e2e/vm-migration/01-migrate.yaml
+++ b/tests/e2e/vm-migration/01-migrate.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- ../../../samples/vm-example-migration.yaml
+unitTest: false


### PR DESCRIPTION
This PR adds a test for VM migration and checks that the connection doesn't break. It uses [`kuttl`](https://kuttl.dev/) as a test tool.

- Create VM with Postgres
- Start workload
  - Wait for Postgres to be able to accept connection using `pg_isready`
  - Create a small db using `pgbench --initialize`
  - Start 10m `pgbench` workload (the duration of the workload should be longer that test duration)
- Check that VM is running
- Migrate VM
- Check that Migration is finished
- Check that `pgbench` is still running

How to run it locally:
- Install `kuttl`: `brew install kuttl` or `go install github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@v0.15.0` or download the binary from their release page https://github.com/kudobuilder/kuttl/releases/tag/v0.15.0
- `make local-cluster`
- `make deploy`
- `make e2e` or, if you want to keep pods running after the test, you can use `kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete` (note, that before running the test next time, you'll need to delete namespace to avoid Postgres ports collision: `kubectl get namespaces --no-headers | awk '/kuttl-test-/ {print $1}' | xargs --no-run-if-empty -n 1 kubectl delete namespace`)

`pgbench` output for the migration timeframe looks like this:


```
pgbench (15.2)
starting vacuum...end.
progress: 1676899716.775 s, 57.0 tps, lat 32.092 ms stddev 12.869, 0 failed
...
progress: 1676899732.775 s, 29.0 tps, lat 73.181 ms stddev 59.306, 0 failed
progress: 1676899733.775 s, 22.0 tps, lat 96.649 ms stddev 60.388, 0 failed
progress: 1676899734.775 s, 21.0 tps, lat 66.528 ms stddev 43.079, 0 failed
progress: 1676899735.776 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
progress: 1676899736.780 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
progress: 1676899737.776 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
...
progress: 1676899760.776 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
progress: 1676899761.776 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
progress: 1676899762.776 s, 0.0 tps, lat 0.000 ms stddev 0.000, 0 failed
progress: 1676899763.775 s, 54.1 tps, lat 1085.284 ms stddev 5378.556, 0 failed
progress: 1676899764.775 s, 73.0 tps, lat 27.662 ms stddev 3.444, 0 failed
progress: 1676899765.775 s, 66.0 tps, lat 29.834 ms stddev 8.584, 0 failed
progress: 1676899766.775 s, 74.0 tps, lat 27.189 ms stddev 4.092, 0 failed
...
```