### PR TITLE
vm-builder: Require --use-inittab to append inittab

### DIFF
--- a/tools/vm-builder/main.go
+++ b/tools/vm-builder/main.go
@@ -86,12 +86,14 @@ RUN chmod +x /neonvm/bin/vminit /neonvm/bin/vmstart
 
 FROM vm-runtime AS builder
 ARG DISK_SIZE
+ARG USE_INITTAB
 COPY --from=rootdisk / /rootdisk
 COPY --from=vm-runtime /neonvm /rootdisk/neonvm
 RUN set -e \
     && mkdir -p /rootdisk/etc \
     && mkdir /rootdisk/etc/vector \
-	&& (cp /rootdisk/etc/inittab /tmp/guest-inittab 2>/dev/null || touch /tmp/guest-inittab) \
+	&& (if [ -n "$USE_INITTAB" ]; then cp /rootdisk/etc/inittab /tmp/guest-inittab 2>/dev/null || true; fi) \
+	&& touch /tmp/guest-inittab \
     && cp -f /rootdisk/neonvm/bin/inittab /rootdisk/etc/inittab \
 	&& cat /tmp/guest-inittab >> /rootdisk/etc/inittab \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
@@ -215,11 +217,12 @@ sinks:
 )
 
 var (
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
-	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
-	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
-	forcePull = flag.Bool("pull", false, `Pull src image even if already present locally`)
+	srcImage   = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
+	dstImage   = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
+	size       = flag.String("size", "1G", `Size for disk image: --size=1G`)
+	outFile    = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	useInittab = flag.Bool("use-inittab", false, `Use guest container's inittab, appending it to the default one`)
+	forcePull  = flag.Bool("pull", false, `Pull src image even if already present locally`)
 )
 
 func printReader(reader io.ReadCloser) error {
@@ -417,6 +420,11 @@ func main() {
 
 	buildArgs := make(map[string]*string)
 	buildArgs["DISK_SIZE"] = size
+	var inittabArg string
+	if *useInittab {
+		inittabArg = "yes"
+	}
+	buildArgs["USE_INITTAB"] = &inittabArg
 
 	opt := types.ImageBuildOptions{
 		Tags: []string{


### PR DESCRIPTION
Some input images for vm-builder contain an /etc/inittab but don't intend on using it. For example:

  https://github.com/neondatabase/neonvm/pull/41#issuecomment-1431283123

This change makes our inttab copying more strict, and off by default. Instead, we now require the --use-inittab flag to enable it.

---

cc @bayandin — I tested that it works with and without `--use-inittab` with the autoscaling sample VM. Both cases seem to function as expected (i.e. the inittab doesn't run without `--use-inittab`), but double-checking would be helpful. Feel free to merge if you're satisfied with it :)